### PR TITLE
add verify IT

### DIFF
--- a/src/it/verify/pom.xml
+++ b/src/it/verify/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2021 The Sigstore Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>sigstore.plugin.it</groupId>
+  <artifactId>verify-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>A simple IT verifying the verify use case.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <binaryFile>pom.xml</binaryFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/dev/sigstore/plugin/verify/SigstoreVerifier.java
+++ b/src/main/java/dev/sigstore/plugin/verify/SigstoreVerifier.java
@@ -56,11 +56,13 @@ public class SigstoreVerifier
 
   public void verifySignature(final File binaryFile) {
     try {
+      LOG.info("checking binary file {}", binaryFile);
       String sha256 = new DigestUtils(SHA_256).digestAsHex(binaryFile);
+      LOG.info("sha256 = {}", sha256);
 
       List<HashedRekordWrapper> rekords = sigstoreClient.getHashedRekordWrappersFromChecksum("sha256", sha256);
 
-      LOG.debug("Found rekords {}", rekords);
+      LOG.info("Found rekords {}", rekords);
 
       processRekords(binaryFile, sha256, rekords);
     }
@@ -99,7 +101,7 @@ public class SigstoreVerifier
 
       String sig = new String(Base64.decodeBase64(Files.readAllBytes(sigFile.toPath())), UTF_8);
 
-      LOG.debug("Processing verification with cert {} and sig {}", certificate, sig);
+      LOG.info("Processing verification with cert {} and sig {}", certificate, sig);
 
       Signature signature = Signature.getInstance("SHA384withECDSA", new BouncyCastleProvider());
       signature.initVerify(certificate.getPublicKey());


### PR DESCRIPTION
run `mvn -Prun-its verify` and check `target/it/verify/build.log` and you'll see

```
[DEBUG] Configuring mojo dev.sigstore:sigstore-maven-plugin:1.0-SNAPSHOT:verify from plugin realm ClassRealm[plugin>dev.sigstore:sigstore-maven-plugin:1.0-SNAPSHOT, parent: jdk.internal.loader.ClassLoaders$AppClassLoader@277050dc]
[DEBUG] Configuring mojo 'dev.sigstore:sigstore-maven-plugin:1.0-SNAPSHOT:verify' with basic configurator -->
[DEBUG]   (f) binaryFile = /Users/hboutemy/dev/git/misc/sigstore-maven-plugin/target/it/verify/pom.xml
[DEBUG] -- end configuration --
[INFO] checking binary file /Users/hboutemy/dev/git/misc/sigstore-maven-plugin/target/it/verify/pom.xml
[INFO] sha256 = 86c53866956a00e54e8c285f7116df270534efcf9851c49bc539831dd60d4847
[DEBUG] Requesting transparency log records from https://rekor.sigstore.dev/api/v1/index/retrieve for checksum sha256:86c53866956a00e54e8c285f7116df270534efcf9851c49bc539831dd60d4847
[DEBUG] Found transparency log uuids: []
[INFO] Found rekords []
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```

the missing part for now is to check a file that has a rekord available